### PR TITLE
Changed structure to support build specific charger configuration 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .vscode/launch.json
 .vscode/*.db
 .vscode/.browse.c_cpp.db*
+src/config.cpp

--- a/README.md
+++ b/README.md
@@ -32,3 +32,5 @@ This mode is only used for lead-acid batteries after several deep-discharge cycl
 ## Toolchain and flashing instructions
 
 See the Libre Solar website for a detailed instruction how to [develop software](http://libre.solar/docs/toolchain/) and [flash new firmware](http://libre.solar/docs/flashing/).
+
+Please note that you have to create the file **config.cpp** by using / changing one of the provided templates to your needs before the software compiles successfully. The file config.cpp is **not** tracked in git since it represents a specific configuration. Please do not add it in a pull request, change the templates if necessary.  

--- a/platformio.ini
+++ b/platformio.ini
@@ -35,7 +35,7 @@ build_flags =
 #monitor_port = /dev/ttyUSB1
 
 ; Custom Serial Monitor baud rate
-monitor_baud = 115200
+monitor_speed = 115200
 
 
 [env:unit_test]

--- a/src/charger.h
+++ b/src/charger.h
@@ -23,8 +23,12 @@
 
 #include "mbed.h"
 
+
 // default values for 12V lead-acid battery
 struct ChargingProfile {
+
+    ChargingProfile();
+    
     int num_cells = 6;
 
     // State: Standby

--- a/src/config.cpp.LeadAcid.template
+++ b/src/config.cpp.LeadAcid.template
@@ -1,0 +1,57 @@
+/* mbed library for a battery charge controller
+ * Copyright (c) 2017 Martin Jäger (www.libre.solar)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "charger.h"
+
+ChargingProfile profile;
+
+
+ChargingProfile::ChargingProfile()
+{
+    num_cells = 6;
+
+    // State: Standby
+    time_limit_recharge = 60; // sec
+    cell_voltage_recharge = 2.3; // V
+    cell_voltage_absolute_min = 1.8; // V   (under this voltage, battery is considered damaged)
+
+    // State: CC/bulk
+    charge_current_max = 20;  // A        PCB maximum: 20 A
+
+    // State: CV/absorption
+    cell_voltage_max = 2.4;        // max voltage per cell
+    time_limit_CV = 120*60; // sec
+    current_cutoff_CV = 2.0; // A
+
+    // State: float/trickle
+    trickle_enabled = true;
+    cell_voltage_trickle = 2.3;    // target voltage for trickle charging of lead-acid batteries
+    time_trickle_recharge = 30*60;     // sec
+
+    // State: equalization
+    equalization_enabled = false;
+    cell_voltage_equalization = 2.5; // V
+    time_limit_equalization = 60*60; // sec
+    current_limit_equalization = 1.0; // A
+    equalization_trigger_time = 8; // weeks
+    equalization_trigger_deep_cycles = 10; // times
+
+    cell_voltage_load_disconnect = 1.95;
+    cell_voltage_load_reconnect = 2.2;
+
+    // TODO
+    temperature_compensation = 1.0;
+}

--- a/src/config.cpp.LiFePo4.template
+++ b/src/config.cpp.LiFePo4.template
@@ -1,0 +1,59 @@
+/* mbed library for a battery charge controller
+ * Copyright (c) 2017 Martin Jäger (www.libre.solar)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "charger.h"
+
+ChargingProfile profile;
+
+
+ChargingProfile::ChargingProfile()
+{
+    // adjust default values for 12V LiFePO4 battery
+    num_cells = 4;
+
+ 
+    // State: Standby
+    time_limit_recharge = 60; // sec
+    cell_voltage_recharge = 3.35; // V
+    cell_voltage_absolute_min = 1.8; // V   (under this voltage, battery is considered damaged)
+
+    // State: CC/bulk
+    charge_current_max = 20;  // A        PCB maximum: 20 A
+
+    // State: CV/absorption
+    cell_voltage_max = 3.55;        // max voltage per cell
+    time_limit_CV = 120*60; // sec
+    current_cutoff_CV = 2.0; // A
+
+    // State: float/trickle
+    trickle_enabled = false;
+    cell_voltage_trickle = 2.3;    // target voltage for trickle charging of lead-acid batteries
+    time_trickle_recharge = 30*60;     // sec
+
+    // State: equalization
+    equalization_enabled = false;
+    cell_voltage_equalization = 2.5; // V
+    time_limit_equalization = 60*60; // sec
+    current_limit_equalization = 1.0; // A
+    equalization_trigger_time = 8; // weeks
+    equalization_trigger_deep_cycles = 10; // times
+
+    cell_voltage_load_disconnect = 3.0;
+    cell_voltage_load_reconnect = 3.15;
+
+    // TODO
+    temperature_compensation = 1.0;
+}

--- a/src/config.cpp.LiIo.template
+++ b/src/config.cpp.LiIo.template
@@ -1,0 +1,57 @@
+/* mbed library for a battery charge controller
+ * Copyright (c) 2017 Martin Jäger (www.libre.solar)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "charger.h"
+
+ChargingProfile profile;
+
+
+ChargingProfile::ChargingProfile()
+{
+    num_cells = 3;
+
+    // State: Standby
+    time_limit_recharge = 60; // sec
+    cell_voltage_recharge = 3.9; // V
+    cell_voltage_absolute_min = 2.7; // V   (under this voltage, battery is considered damaged)
+
+    // State: CC/bulk
+    charge_current_max = 8;  // A        PCB maximum: 20 A
+
+    // State: CV/absorption
+    cell_voltage_max = 4.1;        // max voltage per cell
+    time_limit_CV = 120*60; // sec
+    current_cutoff_CV = 1.0; // A
+
+    // State: float/trickle
+    trickle_enabled = false;
+    cell_voltage_trickle = 2.3;    // target voltage for trickle charging of lead-acid batteries
+    time_trickle_recharge = 30*60;     // sec
+
+    // State: equalization
+    equalization_enabled = false;
+    cell_voltage_equalization = 2.5; // V
+    time_limit_equalization = 60*60; // sec
+    current_limit_equalization = 1.0; // A
+    equalization_trigger_time = 8; // weeks
+    equalization_trigger_deep_cycles = 10; // times
+
+    cell_voltage_load_disconnect = 3.3;
+    cell_voltage_load_reconnect = 3.6;
+
+    // TODO
+    temperature_compensation = 1.0;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,7 +36,7 @@ I2C i2c(PIN_UEXT_SDA, PIN_UEXT_SCL);
 
 DeviceState device;
 CalibrationData cal;
-ChargingProfile profile;
+extern ChargingProfile profile;
 
 float dcdc_power;    // stores previous output power
 int pwm_delta = 1;
@@ -149,14 +149,6 @@ void setup()
     ref_i_dcdc = 0.1;         // 0 for buck, 1 for boost (TODO)
     vbus_disable = 0;
 
-    // adjust default values for 12V LiFePO4 battery
-    profile.num_cells = 4;
-    profile.cell_voltage_max = 3.55;        // max voltage per cell
-    profile.cell_voltage_recharge = 3.35;
-    profile.trickle_enabled = false;
-    profile.cell_voltage_load_disconnect = 3.0;
-    profile.cell_voltage_load_reconnect  = 3.15;
-
     serial.baud(115200);
     printf("\nSerial interface started...\n");
     freopen("/serial", "w", stdout);  // retarget stdout
@@ -188,6 +180,8 @@ void setup()
     CAN1->MCR |= CAN_MCR_TXFP | CAN_MCR_NART;
 }
 
+// this is called regularly after a number of conversion have happend
+// (currently 100, i.e. at 10Hz, see adc_dma.cpp)
 void update_mppt()
 {
     float dcdc_power_new = battery_voltage * dcdc_current;


### PR DESCRIPTION
without tracked changes in GitHub.

When using your software I had to directly change main.cpp just for the sake of adding my 'private' configuration. This hinders collaborative development of software since each pull request would have to be cleaned of these, otherwise you would get commits changing the configuration of you. This is dangerous and a waste of time. 
To eliminate this issue (and possibly due to my lack of knowledge of PlatformIO concepts) I simply outsourced the actual configuration to a file config.cpp by the means of adding a constructor to the struct ChargingProfile. The file config.cpp itself is banned from being submitted to Git / GitHub by means of .gitignore .
I added 3 templates to cover the two existing configurations and a new one for 12V 3S LiIo cells. 
Consquently the build of a just checkout software does not work, one needs to copy one of the templates to config.cpp and modify it to their needs.
