### PR TITLE
Refactoring

### DIFF
--- a/src/data_objects.cpp
+++ b/src/data_objects.cpp
@@ -1,0 +1,49 @@
+/* LibreSolar Battery Management System firmware
+ * Copyright (c) 2016-2018 Martin Jäger (www.libre.solar)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mbed.h"
+#include "config.h"
+
+#include "data_objects.h"
+
+
+static uint16_t oid;
+
+const DataObject_t dataObjects[] {
+    // output data
+    {oid=0x4001, ACCESS_READ, TS_C_OUTPUT, T_FLOAT32, 0, (void*) &(device.bus_voltage), "vBat"},
+    {++oid, ACCESS_READ, TS_C_OUTPUT, T_FLOAT32, 0, (void*) &(device.input_voltage), "vSolar"},
+    {++oid, ACCESS_READ, TS_C_OUTPUT, T_FLOAT32, 0, (void*) &(device.bus_current), "iBat"},
+    {++oid, ACCESS_READ, TS_C_OUTPUT, T_FLOAT32, 0, (void*) &(device.load_current), "iLoad"},
+    {++oid, ACCESS_READ, TS_C_OUTPUT, T_FLOAT32, 0, (void*) &(device.external_temperature), "tempExt"},
+    {++oid, ACCESS_READ, TS_C_OUTPUT, T_FLOAT32, 0, (void*) &(device.internal_temperature), "tempInt"},
+    {++oid, ACCESS_READ, TS_C_OUTPUT, T_BOOL,    0, (void*) &(device.load_enabled), "loaEn"},
+    {++oid, ACCESS_READ, TS_C_OUTPUT, T_FLOAT32, 0, (void*) &(device.input_Wh_day), "eInputDay_Wh"},
+    {++oid, ACCESS_READ, TS_C_OUTPUT, T_FLOAT32, 0, (void*) &(device.output_Wh_day), "eOutputDay_Wh"},
+    {++oid, ACCESS_READ, TS_C_OUTPUT, T_FLOAT32, 0, (void*) &(device.input_Wh_total), "eInputTotal_Wh"},
+    {++oid, ACCESS_READ, TS_C_OUTPUT, T_FLOAT32, 0, (void*) &(device.output_Wh_total), "eOutputTotal_Wh"},
+
+    // calibration data
+    {oid=0x6001, ACCESS_READ | ACCESS_WRITE, TS_C_CAL, T_FLOAT32, 0, (void*) &(cal.dcdc_current_min), "iDcdcMin"},
+    {++oid,   ACCESS_READ | ACCESS_WRITE, TS_C_CAL, T_FLOAT32, 0, (void*) &(cal.solar_voltage_max), "vSolarMax"},
+    {++oid,   ACCESS_READ | ACCESS_WRITE, TS_C_CAL, T_INT32,  0, (void*) &(cal.dcdc_restart_interval), "tDcdcRestart"},
+    {++oid,   ACCESS_READ | ACCESS_WRITE, TS_C_CAL, T_FLOAT32, 0, (void*) &(cal.solar_voltage_offset_start), "vSolarOffsetStart"},
+    {++oid,   ACCESS_READ | ACCESS_WRITE, TS_C_CAL, T_FLOAT32, 0, (void*) &(cal.solar_voltage_offset_stop), "vSolarOffsetStop"},
+    {++oid,   ACCESS_READ | ACCESS_WRITE, TS_C_CAL, T_INT32,  0, (void*) &(cal.thermistor_beta_value), "thermistorBetaValue"}
+};
+
+const size_t dataObjectsCount = sizeof(dataObjects)/sizeof(DataObject_t);
+

--- a/src/data_objects.h
+++ b/src/data_objects.h
@@ -109,29 +109,7 @@ typedef struct {
 #define ACCESS_READ_AUTH (0x1U << 2)       // read after authentication
 #define ACCESS_WRITE_AUTH (0x1U << 3)      // write after authentication
 
-static uint16_t oid;
-
-static const DataObject_t dataObjects[] {
-    // output data
-    {oid=0x4001, ACCESS_READ, TS_C_OUTPUT, T_FLOAT32, 0, (void*) &(device.bus_voltage), "vBat"},
-    {++oid, ACCESS_READ, TS_C_OUTPUT, T_FLOAT32, 0, (void*) &(device.input_voltage), "vSolar"},
-    {++oid, ACCESS_READ, TS_C_OUTPUT, T_FLOAT32, 0, (void*) &(device.bus_current), "iBat"},
-    {++oid, ACCESS_READ, TS_C_OUTPUT, T_FLOAT32, 0, (void*) &(device.load_current), "iLoad"},
-    {++oid, ACCESS_READ, TS_C_OUTPUT, T_FLOAT32, 0, (void*) &(device.external_temperature), "tempExt"},
-    {++oid, ACCESS_READ, TS_C_OUTPUT, T_FLOAT32, 0, (void*) &(device.internal_temperature), "tempInt"},
-    {++oid, ACCESS_READ, TS_C_OUTPUT, T_BOOL,    0, (void*) &(device.load_enabled), "loaEn"},
-    {++oid, ACCESS_READ, TS_C_OUTPUT, T_FLOAT32, 0, (void*) &(device.input_Wh_day), "eInputDay_Wh"},
-    {++oid, ACCESS_READ, TS_C_OUTPUT, T_FLOAT32, 0, (void*) &(device.output_Wh_day), "eOutputDay_Wh"},
-    {++oid, ACCESS_READ, TS_C_OUTPUT, T_FLOAT32, 0, (void*) &(device.input_Wh_total), "eInputTotal_Wh"},
-    {++oid, ACCESS_READ, TS_C_OUTPUT, T_FLOAT32, 0, (void*) &(device.output_Wh_total), "eOutputTotal_Wh"},
-
-    // calibration data
-    {oid=0x6001, ACCESS_READ | ACCESS_WRITE, TS_C_CAL, T_FLOAT32, 0, (void*) &(cal.dcdc_current_min), "iDcdcMin"},
-    {++oid,   ACCESS_READ | ACCESS_WRITE, TS_C_CAL, T_FLOAT32, 0, (void*) &(cal.solar_voltage_max), "vSolarMax"},
-    {++oid,   ACCESS_READ | ACCESS_WRITE, TS_C_CAL, T_INT32,  0, (void*) &(cal.dcdc_restart_interval), "tDcdcRestart"},
-    {++oid,   ACCESS_READ | ACCESS_WRITE, TS_C_CAL, T_FLOAT32, 0, (void*) &(cal.solar_voltage_offset_start), "vSolarOffsetStart"},
-    {++oid,   ACCESS_READ | ACCESS_WRITE, TS_C_CAL, T_FLOAT32, 0, (void*) &(cal.solar_voltage_offset_stop), "vSolarOffsetStop"},
-    {++oid,   ACCESS_READ | ACCESS_WRITE, TS_C_CAL, T_INT32,  0, (void*) &(cal.thermistor_beta_value), "thermistorBetaValue"}
-};
+extern const DataObject_t dataObjects[]; // see output_can.cpp
+extern const size_t dataObjectsCount;
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -321,7 +321,7 @@ void init_watchdog(float timeout) {
     IWDG->RLR = (uint32_t)(timeout * (LSI_FREQ/prescaler));
     
     calculated_timeout = ((float)(prescaler * IWDG->RLR)) / LSI_FREQ;
-    printf("WATCHDOG set with prescaler:%d reload value: 0x%X - timeout:%f\n",prescaler, IWDG->RLR, calculated_timeout);
+    printf("WATCHDOG set with prescaler:%d reload value: 0x%lX - timeout:%f\n",prescaler, IWDG->RLR, calculated_timeout);
     
     IWDG->KR = 0xAAAA;  // reload
     IWDG->KR = 0xCCCC;  // start

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -94,7 +94,7 @@ void output_serial_json()
 {
     serial.printf("{");
     bool first = true;
-    for(unsigned int i = 0; i < sizeof(dataObjects)/sizeof(DataObject_t); ++i) {
+    for(unsigned int i = 0; i < dataObjectsCount; ++i) {
         if (first == false) {
             serial.printf(",");
         }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -172,19 +172,19 @@ void output_oled()
     oled.printf("T %.1f PWM %.1f%% ", device.internal_temperature, dcdc_get_duty_cycle() * 100.0);
     switch (charger_get_state()) {
         case CHG_IDLE:
-            oled.printf("Idle\n");
+            oled.printf("Idle");
             break;
         case CHG_CC:
-            oled.printf("CC charge\n");
+            oled.printf("CC");
             break;
         case CHG_CV:
-            oled.printf("CV charge\n");
+            oled.printf("CV");
             break;
         case CHG_TRICKLE:
-            oled.printf("Trickle chg\n");
+            oled.printf("Trkl");
             break;
         default:
-            oled.printf("Error\n");
+            oled.printf("Err.");
             break;
     }
     oled.display();

--- a/src/output_can.cpp
+++ b/src/output_can.cpp
@@ -139,7 +139,7 @@ void can_pub_msg(DataObject_t data_obj)
 
 void can_send_data()
 {
-    for (unsigned int i = 0; i < sizeof(dataObjects)/sizeof(DataObject_t); ++i) {
+    for (unsigned int i = 0; i < dataObjectsCount; ++i) {
         if (dataObjects[i].category == TS_C_OUTPUT) {
             can_pub_msg(dataObjects[i]);
         }
@@ -175,7 +175,7 @@ void can_send_object_name(int data_obj_id, uint8_t can_dest_id) {
     msg.id = msg_priority << 26 | function_id << 16 |(can_dest_id << 8)| can_node_id;      // TODO: add destination node ID
 
     int arr_id = -1;
-    for (int idx = 0; idx < sizeof(dataObjects)/sizeof(DataObject_t); idx++) {
+    for (unsigned int idx = 0; idx < dataObjectsCount; idx++) {
         if (dataObjects[idx].id == data_obj_id) {
             arr_id = idx;
             break;  // correct array entry found
@@ -229,7 +229,7 @@ void can_process_inbox() {
                 case TS_WRITE:
                     data_obj_id = msg.data[1] + (msg.data[2] << 8);
                     value = msg.data[6] + (msg.data[7] << 8);
-                    for (unsigned int i = 0; i < sizeof(dataObjects)/sizeof(DataObject_t); ++i) {
+                    for (unsigned int i = 0; i < dataObjectsCount; ++i) {
                         if (dataObjects[i].id == data_obj_id) {
                             if (dataObjects[i].access & ACCESS_WRITE) {
                                 // TODO: write data


### PR DESCRIPTION
Minor changes, most notably the moving of the DataObjects[] to its own file, see commit message for background. Be aware to use dataObjectsCount in place where the number of dataObjects in the array is required (instead of the sizeof/sizeof calculation).

Other change fixes a minor warning and the too long charger state names for the OLED display.