### PR TITLE
Small platformio.ini fixes

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -16,6 +16,7 @@ env_default = libresolar_0_10
 
 [common]
 
+lib_ignore = mbed-USBDevice
 #platform = https://github.com/platformio/platform-ststm32.git
 
 upload_protocol = stlink
@@ -34,6 +35,7 @@ monitor_speed = 57600
 build_flags =
 #    -Wl,-u_printf_float
 #    -fstack-usage
+    -Wl,-Map,memory.map
     -D PCB_LS_010=1
     -D MBED_CONF_TARGET_LSE_AVAILABLE=0
     -D MBED_CONF_TARGET_STDIO_UART_TX=PA_9
@@ -52,6 +54,7 @@ monitor_port = ${common.monitor_port}
 monitor_speed = ${common.monitor_port}
 build_flags = ${common.build_flags}
     -D PCB_LS_005=1
+lib_ignore = mbed-USBDevice
 
 [env:libresolar_0_10]
 platform = ststm32
@@ -61,10 +64,12 @@ upload_protocol = ${common.upload_protocol}
 monitor_port = ${common.monitor_port}
 monitor_speed = ${common.monitor_port}
 build_flags = ${common.build_flags}
-    -D PCB_LS_005=1
+    -D PCB_LS_010=1
     -D MBED_CONF_TARGET_STDIO_UART_TX=PA_9
     -D MBED_CONF_TARGET_STDIO_UART_RX=PA_10
-    
+
+lib_ignore = mbed-USBDevice
+
 [env:cloudsolar_0_2]
 platform = ststm32
 framework = mbed
@@ -76,6 +81,7 @@ build_flags = ${common.build_flags}
     -D PCB_CS_02=1
     -D MBED_CONF_TARGET_STDIO_UART_TX=PA_9
     -D MBED_CONF_TARGET_STDIO_UART_RX=PA_10
+lib_ignore = mbed-USBDevice
 
 [env:cloudsolar_0_3]
 platform = ststm32
@@ -107,7 +113,7 @@ build_flags = ${common.build_flags}
 # - disable LP ticker based on LPTIM (because does not work...)
 #    -D PIO_FRAMEWORK_MBED_RTOS_PRESENT
 #    -D PIO_FRAMEWORK_MBED_EVENTS_PRESENT
-
+lib_ignore = mbed-USBDevice
 
 [env:unit_test_native]
 platform = native
@@ -129,3 +135,4 @@ build_flags =
     -std=c++11
     -DMBED_CONF_TARGET_LSE_AVAILABLE=0
 #    -DPIO_FRAMEWORK_MBED_RTOS_PRESENT
+lib_ignore = mbed-USBDevice


### PR DESCRIPTION
- added libignore for mbed-USBDevice to all STM32F072 builds
- add map file generation. Use text editor or AMAP (http://www.sikorskiy.net/prj/amap/)
to view and learn where the precious flash and ram goes to.
- fixed board define for LS 0.10 board