### PR TITLE
Cell & Pack Config refactoring: First work on #13.

### DIFF
--- a/src/charger.h
+++ b/src/charger.h
@@ -24,7 +24,7 @@
 extern "C" {
 #endif
 
-void battery_init(battery_t* bat, int type, int capacity_Ah);
+void battery_init(battery_t* bat, int type, int capacity_Ah, int num_cells_series);
 
 /* Initialize DC/DC and DC/DC port structs
  *

--- a/src/data_objects.h
+++ b/src/data_objects.h
@@ -35,7 +35,6 @@ extern dcdc_port_t ls_port;
 extern const data_object_t dataObjects[]; // see output_can.cpp
 extern const size_t dataObjectsCount;
 
-static bool pub_data_enabled = 0;
 
 // stores object-ids of values to be stored in EEPROM
 static const int eeprom_data_objects[] = {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -76,6 +76,9 @@ Timer tim;
 void setup();
 void energy_counter();
 
+// static variables (only visible in this  file)
+static bool pub_data_enabled;
+
 void check_overcurrent()
 {
     if (load.current > load.current_max) {
@@ -191,8 +194,8 @@ void setup()
     //printf("\nSerial interface started...\n");
     //freopen("/serial", "w", stdout);  // retarget stdout
 
-    battery_init(&bat, BAT_TYPE_FLOODED, 7);
-    //battery_init(&bat, BAT_TYPE_LFP, 20);
+    battery_init(&bat, BAT_TYPE_FLOODED, 7, 6);
+    //battery_init(&bat, BAT_TYPE_LFP, 20, 4);
 
     dcdc_init(&dcdc);
 

--- a/src/structs.h
+++ b/src/structs.h
@@ -19,6 +19,7 @@ extern "C" {
 
 typedef struct
 {
+    // configuration data (r any time, write only at startup / init, change requires reinit of charger )
     int num_cells;
     int capacity;
 
@@ -56,6 +57,10 @@ typedef struct
 
     float temperature_compensation;     // voltage compensation (suggested: -3 mV/°C/cell)
 
+    bool valid_config;
+
+    // operational data below (r/w during operation)
+
     float temperature;                  // °C from ext. temperature sensor (if existing)
     
     float input_Wh_day;
@@ -76,7 +81,7 @@ typedef struct
 
 // battery types 
 enum {
-    BAT_TYPE_DEFAULT,        // stafe standard settings
+    BAT_TYPE_NONE,        // stafe standard settings
     BAT_TYPE_FLOODED,        // old flooded (wet) lead-acid batteries
     BAT_TYPE_GEL,            // VRLA gel batteries (maintainance-free)
     BAT_TYPE_AGM,            // AGM batteries (maintainance-free)


### PR DESCRIPTION
Reorganized battery init a bit to get a better idea of how to split things.
All known chemistries are now supported with safe values (please check the values).

Added data for NMC (aka "normal" LiIo cells such as most 18650)
A configuration now declares itself to be valid or not after battery_init.

BAT_TYPE_NONE (formerly BAT_TYPE_DEFAULT, which equals 0) will not pass check
and thus is an invalid configuration, as a result an unconfigured
battery_t struct will not be considered valid by accident.

We should not continue to start normal operation if a battery configuration is not valid.
However, this is not yet implemented.

Also slightly changed interface to battery_init, now we pass the number of cells.

Moved the static pub_enabled into main.cpp to get ride of a ton of "unused static variable"
warnings.