### PR TITLE
Improved User Config support, less warnings, minor stuff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,6 @@ install:
     # - platformio lib -g install 4ee c23 
 
 script:
-        #- cp src/config.cpp.LeadAcid.template src/config.cpp
+        - cp src/config.cpp.LeadAcid.template src/config.cpp
         # - platformio ci --lib="lib/Adafruit_GFX" --lib="lib/ThingSet" --project-conf=platformio.ini -e libresolar_0_10,libresolar_0_05 
         - platformio run -e libresolar_0_10 -e libresolar_0_05 -e cloudsolar_0_2 -e cloudsolar_0_3

--- a/lib/USBSerial/USBSerial.cpp
+++ b/lib/USBSerial/USBSerial.cpp
@@ -18,6 +18,9 @@
 
 #ifndef UNIT_TEST
 
+#ifdef TURN_OFF_MBED_DEPRECATED_WARNNG
+    #define MBED_DEPRECATED(a)
+#endif
 #include "stdint.h"
 #include "USBSerial.h"
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -37,7 +37,7 @@ build_flags =
 #    -fstack-usage
     -Wl,-Map,memory.map
     -D MBED_CONF_TARGET_LSE_AVAILABLE=0
-    -D MBED_DEPRECATED(a)=
+    -D "MBED_DEPRECATED(a)="
 # removes deprecated warnings until mbed fixes USBOD stack 		
 #    -D PIO_FRAMEWORK_MBED_RTOS_PRESENT
 #    -D PIO_FRAMEWORK_MBED_EVENTS_PRESENT

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,7 @@
 
 [platformio]
 #env_default = libresolar_0_05
-#env_default = libresolar_0_10
+env_default = libresolar_0_10, cloudsolar_0_3
 #env_default = cloudsolar_0_3
 #env_default = unit_test_native
 
@@ -37,7 +37,7 @@ build_flags =
 #    -fstack-usage
     -Wl,-Map,memory.map
     -D MBED_CONF_TARGET_LSE_AVAILABLE=0
-    -D "MBED_DEPRECATED(a)="
+    -D TURN_OFF_MBED_DEPRECATED_WARNNG
 # removes deprecated warnings until mbed fixes USBOD stack 		
 #    -D PIO_FRAMEWORK_MBED_RTOS_PRESENT
 #    -D PIO_FRAMEWORK_MBED_EVENTS_PRESENT

--- a/platformio.ini
+++ b/platformio.ini
@@ -37,6 +37,8 @@ build_flags =
 #    -fstack-usage
     -Wl,-Map,memory.map
     -D MBED_CONF_TARGET_LSE_AVAILABLE=0
+    -D MBED_DEPRECATED(a)=
+# removes deprecated warnings until mbed fixes USBOD stack 		
 #    -D PIO_FRAMEWORK_MBED_RTOS_PRESENT
 #    -D PIO_FRAMEWORK_MBED_EVENTS_PRESENT
 

--- a/src/charger.cpp
+++ b/src/charger.cpp
@@ -33,20 +33,71 @@ void _enter_state(battery_t* bat, int next_state)
     bat->state = next_state;
 }
 
-void battery_init(battery_t* bat, int type, int capacity_Ah, int num_cells)
+static void set_to_default_if_zero(float& value, const float defaultValue)
 {
-    // init to safe defaults
-    bat->charge_current_max = 20;               // A        PCB maximum: 20 A
+    if (value == 0) 
+    {
+        value = defaultValue;
+    }
+}
+
+//template <typename V, typename D> static void set_to_max_if_too_high(V& value, const D defaultValue)
+static void set_to_max_if_too_high(float& value, const float defaultValue)
+{
+    if (value > defaultValue) 
+    {
+        value = defaultValue;
+    }
+}
+/* template <typename V, typename D> static void set_to_min_if_too_low(V& value, const D defaultValue)
+static void set_to_min_if_too_low(float& value, const float defaultValue)
+{
+    if (value < defaultValue) 
+    {
+        value = defaultValue;
+    }
+}
+*/
+//template <typename V, typename D, typename MI, typename MA> static void set_default_if_out_of_range(V& value, const D defaultValue, const MI min, const MA max)
+static void set_default_if_out_of_range(float& value, const float defaultValue, const float min, const float max)
+{
+    if (value <= min || value >= max) 
+    {
+        value = defaultValue;
+    }
+}
+
+
+// mandatory: battery cell type
+// optional: user settable charge_current_max (can be calculated from capacity, leave charge_current_max == 0)
+// optional: cell_voltage_max,  cell_voltage_recharge,cell_voltage_load_disconnect, cell_voltage_load_reconnect
+// leave values at 0 to get default values
+
+void battery_init(battery_t* bat, BatteryType type, float capacity_Ah, int num_cells)
+{
+
+    // battery pack specific information
+    bat->num_cells = num_cells; 
+
+    bat->capacity = capacity_Ah;
+
+    // if we get zero, set to safe 1Ah
+    set_to_default_if_zero(bat->capacity, 1.0f);
+
+    // init to safe defaults (1C charging)
+    set_to_default_if_zero(bat->charge_current_max, bat->capacity);
+
+    // capacity not specified or too high capacity or current requested
+    // no more than 2C permitted
+    set_to_max_if_too_high(bat->charge_current_max, 2*bat->capacity) ;
+    // must not exceed PCB max current
+    set_to_max_if_too_high(bat->charge_current_max, DCDC_CURRENT_MAX) ;
 
      // Trickle / Equalization Charge Configuration ONLY FOR LEAD-ACID 
     bat->trickle_enabled = false;
     bat->equalization_enabled = false;          // only for lead acid
     bat->valid_config = false; // just to be on the safe side
  
-    // battery pack specific information
-    bat->num_cells = num_cells; 
-
-    bat->capacity = capacity_Ah;
 
     // common values (shared for all battery types)
 
@@ -60,10 +111,11 @@ void battery_init(battery_t* bat, int type, int capacity_Ah, int num_cells)
         case BAT_TYPE_FLOODED:
         case BAT_TYPE_AGM:
         case BAT_TYPE_GEL:
+            bat->cell_voltage_absolute_min = 1.8;       // V   (under this voltage, battery is considered damaged)
+            bat->cell_voltage_absolute_max = 2.5;       // V   (above this voltage, battery may become damaged)
             
             bat->cell_voltage_max = 2.4;                // CV/absorption stage
             bat->cell_voltage_recharge = 2.3;           // V
-            bat->cell_voltage_absolute_min = 1.8;       // V   (under this voltage, battery is considered damaged)
 
             bat->cell_voltage_load_disconnect = 1.9;    // 1.95
             bat->cell_voltage_load_reconnect = 2.0;     // 2.2
@@ -97,33 +149,67 @@ void battery_init(battery_t* bat, int type, int capacity_Ah, int num_cells)
             bat->temperature_compensation = -0.003;     // -3 mV/°C/cell
             bat->valid_config = true;
             break;
+
         case BAT_TYPE_LFP:
-                // 12V LiFePO4 battery
+            bat->cell_voltage_absolute_min = 2.0;       // V   (under this voltage, battery is considered damaged)
+            bat->cell_voltage_absolute_max = 3.6;
+
+            // 12V LiFePO4 battery
+            set_default_if_out_of_range(bat->cell_voltage_max,               bat->cell_voltage_absolute_max,         bat->cell_voltage_absolute_min,         bat->cell_voltage_absolute_max);
+            set_default_if_out_of_range(bat->cell_voltage_load_disconnect,   3.0,                                    2.5,                                    bat->cell_voltage_max - 0.2);
+            set_default_if_out_of_range(bat->cell_voltage_load_reconnect,    bat->cell_voltage_load_disconnect+0.15, bat->cell_voltage_load_disconnect+0.1,  bat->cell_voltage_max - 0.1);
+            set_default_if_out_of_range(bat->cell_voltage_recharge,          bat->cell_voltage_max - 0.2,            bat->cell_voltage_absolute_min + 0.1,   bat->cell_voltage_max - 0.1);
+            set_default_if_out_of_range(bat->current_cutoff_CV,              bat->capacity / 10.0,                     0.0001,                                 bat->charge_current_max * 0.9) ;  
+            // C/10 cut-off at end of CV phase by default
+    
+            /*
             bat->cell_voltage_max = 3.55;               // CV voltage
             bat->cell_voltage_recharge = 3.35;
             bat->cell_voltage_load_disconnect = 3.0;
             bat->cell_voltage_load_reconnect  = 3.15;
-            
-            bat->trickle_enabled = false;
-            bat->equalization_enabled = false;
-            bat->temperature_compensation = 0.0;
-            bat->current_cutoff_CV = bat->capacity / 10;  // C/10 cut-off at end of CV phase
-            bat->valid_config = true;
-            break;
-        case BAT_TYPE_NMC:
-            bat->cell_voltage_max = 4.20;               // CV voltage
-            bat->cell_voltage_recharge = 4.00;
-            bat->cell_voltage_load_disconnect = 3.3;
-            bat->cell_voltage_load_reconnect  = 3.6;
+            bat->current_cutoff_CV = bat->capacity / 10;
+            */
 
             bat->trickle_enabled = false;
             bat->equalization_enabled = false;
             bat->temperature_compensation = 0.0;
-            bat->current_cutoff_CV = bat->capacity / 10;  // C/10 cut-off at end of CV phase
             bat->valid_config = true;
             break;
+
+        case BAT_TYPE_NMC:
+        case BAT_TYPE_NMC_HV:
+            bat->cell_voltage_absolute_min = 2.5;       // V   (under this voltage, battery is considered damaged)
+            bat->cell_voltage_absolute_max = type==BAT_TYPE_NMC_HV? 4.35 : 4.20;
+
+            set_default_if_out_of_range(bat->cell_voltage_max,               bat->cell_voltage_absolute_max-0.1,     bat->cell_voltage_absolute_min+0.7,     bat->cell_voltage_absolute_max);
+            set_default_if_out_of_range(bat->cell_voltage_load_disconnect,   3.3,                                    3.0,                                    bat->cell_voltage_max - 0.2);
+            set_default_if_out_of_range(bat->cell_voltage_load_reconnect,    bat->cell_voltage_load_disconnect+0.3,  bat->cell_voltage_load_disconnect+0.1,  bat->cell_voltage_max - 0.1);
+            set_default_if_out_of_range(bat->cell_voltage_recharge,          bat->cell_voltage_max - 0.2,            bat->cell_voltage_absolute_min + 0.1,   bat->cell_voltage_max - 0.1);
+            set_default_if_out_of_range(bat->current_cutoff_CV,              bat->capacity / 10.0,                   0.0001,                                 bat->charge_current_max * 0.9) ;  
+            // C/10 cut-off at end of CV phase by default
+     
+            /* 
+            bat->cell_voltage_max = 4.1;               // CV voltage
+            bat->cell_voltage_recharge = 3.9;
+            bat->cell_voltage_load_disconnect = 3.3;
+            bat->cell_voltage_load_reconnect  = 3.6;
+            bat->current_cutoff_CV = bat->capacity / 10;
+            */
+
+            bat->trickle_enabled = false;
+            bat->equalization_enabled = false;
+            bat->temperature_compensation = 0.0;
+            bat->valid_config = true;
+            break;
+
         default:
             bat->valid_config = false;
+    }
+
+    // a valid config must have at least one cell
+    if (bat->num_cells == 0)
+    {
+        bat->valid_config = false;
     }
 }
 

--- a/src/charger.cpp
+++ b/src/charger.cpp
@@ -73,13 +73,19 @@ static void set_default_if_out_of_range(float& value, const float defaultValue, 
 // optional: cell_voltage_max,  cell_voltage_recharge,cell_voltage_load_disconnect, cell_voltage_load_reconnect
 // leave values at 0 to get default values
 
-void battery_init(battery_t* bat, BatteryType type, float capacity_Ah, int num_cells)
+void battery_init(battery_t* bat, BatteryConfigUser& batDesc)
 {
 
     // battery pack specific information
-    bat->num_cells = num_cells; 
-
-    bat->capacity = capacity_Ah;
+    bat->num_cells = batDesc.num_cells; 
+    bat->capacity = batDesc.capacity;
+    
+    bat->cell_voltage_max = batDesc.cell_voltage_max;
+    bat->cell_voltage_recharge = batDesc.cell_voltage_recharge;
+    bat->cell_voltage_load_disconnect = batDesc.cell_voltage_load_disconnect;
+    bat->cell_voltage_load_reconnect = batDesc.cell_voltage_load_reconnect;
+    bat->charge_current_max = batDesc.charge_current_max;
+    bat->current_cutoff_CV = batDesc.current_cutoff_CV;
 
     // if we get zero, set to safe 1Ah
     set_to_default_if_zero(bat->capacity, 1.0f);
@@ -106,7 +112,7 @@ void battery_init(battery_t* bat, BatteryType type, float capacity_Ah, int num_c
     bat->time_limit_recharge = 60;              // sec
     bat->time_limit_CV = 120*60;                // sec
 
-    switch (type)
+    switch (batDesc.type)
     {
         case BAT_TYPE_FLOODED:
         case BAT_TYPE_AGM:
@@ -132,7 +138,7 @@ void battery_init(battery_t* bat, BatteryType type, float capacity_Ah, int num_c
             // Trickle Charge Voltage Configuration
             bat->cell_voltage_trickle = 2.3;            // target voltage for trickle charging of lead-acid batteries
 
-            if (type == BAT_TYPE_FLOODED) {
+            if (batDesc.type == BAT_TYPE_FLOODED) {
                 // http://batteryuniversity.com/learn/article/charging_the_lead_acid_battery
                 bat->cell_voltage_trickle = 2.25;
             }
@@ -159,7 +165,7 @@ void battery_init(battery_t* bat, BatteryType type, float capacity_Ah, int num_c
             set_default_if_out_of_range(bat->cell_voltage_load_disconnect,   3.0,                                    2.5,                                    bat->cell_voltage_max - 0.2);
             set_default_if_out_of_range(bat->cell_voltage_load_reconnect,    bat->cell_voltage_load_disconnect+0.15, bat->cell_voltage_load_disconnect+0.1,  bat->cell_voltage_max - 0.1);
             set_default_if_out_of_range(bat->cell_voltage_recharge,          bat->cell_voltage_max - 0.2,            bat->cell_voltage_absolute_min + 0.1,   bat->cell_voltage_max - 0.1);
-            set_default_if_out_of_range(bat->current_cutoff_CV,              bat->capacity / 10.0,                     0.0001,                                 bat->charge_current_max * 0.9) ;  
+            set_default_if_out_of_range(bat->current_cutoff_CV,              bat->capacity / 10.0,                   0.0001,                                 bat->charge_current_max * 0.9) ;  
             // C/10 cut-off at end of CV phase by default
     
             /*
@@ -179,7 +185,7 @@ void battery_init(battery_t* bat, BatteryType type, float capacity_Ah, int num_c
         case BAT_TYPE_NMC:
         case BAT_TYPE_NMC_HV:
             bat->cell_voltage_absolute_min = 2.5;       // V   (under this voltage, battery is considered damaged)
-            bat->cell_voltage_absolute_max = type==BAT_TYPE_NMC_HV? 4.35 : 4.20;
+            bat->cell_voltage_absolute_max = batDesc.type==BAT_TYPE_NMC_HV? 4.35 : 4.20;
 
             set_default_if_out_of_range(bat->cell_voltage_max,               bat->cell_voltage_absolute_max-0.1,     bat->cell_voltage_absolute_min+0.7,     bat->cell_voltage_absolute_max);
             set_default_if_out_of_range(bat->cell_voltage_load_disconnect,   3.3,                                    3.0,                                    bat->cell_voltage_max - 0.2);

--- a/src/charger.h
+++ b/src/charger.h
@@ -24,7 +24,7 @@
 extern "C" {
 #endif
 
-void battery_init(battery_t* bat, BatteryType type, float capacity_Ah, int num_cells_series);
+void battery_init(battery_t* bat, BatteryConfigUser&);
 
 /* Initialize DC/DC and DC/DC port structs
  *

--- a/src/charger.h
+++ b/src/charger.h
@@ -24,7 +24,7 @@
 extern "C" {
 #endif
 
-void battery_init(battery_t* bat, int type, int capacity_Ah, int num_cells_series);
+void battery_init(battery_t* bat, BatteryType type, float capacity_Ah, int num_cells_series);
 
 /* Initialize DC/DC and DC/DC port structs
  *

--- a/src/config.cpp.LeadAcid.template
+++ b/src/config.cpp.LeadAcid.template
@@ -1,5 +1,5 @@
-/* mbed library for a battery charge controller
- * Copyright (c) 2017 Martin Jäger (www.libre.solar)
+/* LibreSolar MPPT charge controller firmware
+ * Copyright (c) 2016-2018 Martin Jäger (www.libre.solar)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,44 +14,30 @@
  * limitations under the License.
  */
 
-#include "charger.h"
-
-ChargingProfile profile;
 
 
-ChargingProfile::ChargingProfile()
+#include "data_objects.h"
+
+const SystemMode system_mode = MPPT_CHARGER; // MPPT_CHARGER or NANOGRID 
+
+BatteryConfigUser battery_config_user;
+
+BatteryConfigUser::BatteryConfigUser()
 {
-    num_cells = 6;
+    type = BAT_TYPE_FLOODED; // mandatory
+    capacity = 7; // mandatory
+    num_cells = 6; // mandatory
 
-    // State: Standby
-    time_limit_recharge = 60; // sec
-    cell_voltage_recharge = 2.3; // V
-    cell_voltage_absolute_min = 1.8; // V   (under this voltage, battery is considered damaged)
-
+    // all batteries can optionally use these values, leave at 0 to set automatically
     // State: CC/bulk
-    charge_current_max = 20;  // A        PCB maximum: 20 A
+    charge_current_max = 0;        // A
+    current_cutoff_CV = 0;       // A
 
+    // Lithium batteries can optionally use these values, leave at 0 to set automatically
     // State: CV/absorption
-    cell_voltage_max = 2.4;        // max voltage per cell
-    time_limit_CV = 120*60; // sec
-    current_cutoff_CV = 2.0; // A
+    cell_voltage_max = 0;        // max charge voltage per cell
+    cell_voltage_recharge = 0;   // when voltage drops below start charging after battery full
 
-    // State: float/trickle
-    trickle_enabled = true;
-    cell_voltage_trickle = 2.3;    // target voltage for trickle charging of lead-acid batteries
-    time_trickle_recharge = 30*60;     // sec
-
-    // State: equalization
-    equalization_enabled = false;
-    cell_voltage_equalization = 2.5; // V
-    time_limit_equalization = 60*60; // sec
-    current_limit_equalization = 1.0; // A
-    equalization_trigger_time = 8; // weeks
-    equalization_trigger_deep_cycles = 10; // times
-
-    cell_voltage_load_disconnect = 1.95;
-    cell_voltage_load_reconnect = 2.2;
-
-    // TODO
-    temperature_compensation = 1.0;
+    cell_voltage_load_disconnect = 0; // when discharging, stop power to load measure battery voltage drops below this value
+    cell_voltage_load_reconnect = 0;  // when charging, only start power to load if reaching this battery voltage  
 }

--- a/src/config.cpp.LiFePo4.template
+++ b/src/config.cpp.LiFePo4.template
@@ -1,5 +1,5 @@
-/* mbed library for a battery charge controller
- * Copyright (c) 2017 Martin Jäger (www.libre.solar)
+/* LibreSolar MPPT charge controller firmware
+ * Copyright (c) 2016-2018 Martin Jäger (www.libre.solar)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,46 +14,30 @@
  * limitations under the License.
  */
 
-#include "charger.h"
-
-ChargingProfile profile;
 
 
-ChargingProfile::ChargingProfile()
+#include "data_objects.h"
+
+onst SystemMode system_mode = MPPT_CHARGER; // MPPT_CHARGER or NANOGRID 
+
+BatteryConfigUser battery_config_user;
+
+BatteryConfigUser::BatteryConfigUser()
 {
-    // adjust default values for 12V LiFePO4 battery
-    num_cells = 4;
+    type = BAT_TYPE_LFP; // mandatory
+    capacity = 20; // mandatory
+    num_cells = 4; // mandatory
 
- 
-    // State: Standby
-    time_limit_recharge = 60; // sec
-    cell_voltage_recharge = 3.35; // V
-    cell_voltage_absolute_min = 1.8; // V   (under this voltage, battery is considered damaged)
-
+    // all batteries can optionally use these values, leave at 0 to set automatically
     // State: CC/bulk
-    charge_current_max = 20;  // A        PCB maximum: 20 A
+    charge_current_max = 0;        // A
+    current_cutoff_CV = 0;       // A
 
+    // Lithium batteries can optionally use these values, leave at 0 to set automatically
     // State: CV/absorption
-    cell_voltage_max = 3.55;        // max voltage per cell
-    time_limit_CV = 120*60; // sec
-    current_cutoff_CV = 2.0; // A
+    cell_voltage_max = 0;        // max charge voltage per cell
+    cell_voltage_recharge = 0;   // when voltage drops below start charging after battery full
 
-    // State: float/trickle
-    trickle_enabled = false;
-    cell_voltage_trickle = 2.3;    // target voltage for trickle charging of lead-acid batteries
-    time_trickle_recharge = 30*60;     // sec
-
-    // State: equalization
-    equalization_enabled = false;
-    cell_voltage_equalization = 2.5; // V
-    time_limit_equalization = 60*60; // sec
-    current_limit_equalization = 1.0; // A
-    equalization_trigger_time = 8; // weeks
-    equalization_trigger_deep_cycles = 10; // times
-
-    cell_voltage_load_disconnect = 3.0;
-    cell_voltage_load_reconnect = 3.15;
-
-    // TODO
-    temperature_compensation = 1.0;
+    cell_voltage_load_disconnect = 0; // when discharging, stop power to load measure battery voltage drops below this value
+    cell_voltage_load_reconnect = 0;  // when charging, only start power to load if reaching this battery voltage  
 }

--- a/src/config.cpp.LiIo.template
+++ b/src/config.cpp.LiIo.template
@@ -1,5 +1,5 @@
-/* mbed library for a battery charge controller
- * Copyright (c) 2017 Martin Jäger (www.libre.solar)
+/* LibreSolar MPPT charge controller firmware
+ * Copyright (c) 2016-2018 Martin Jäger (www.libre.solar)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,44 +14,31 @@
  * limitations under the License.
  */
 
-#include "charger.h"
-
-ChargingProfile profile;
 
 
-ChargingProfile::ChargingProfile()
+#include "data_objects.h"
+
+const SystemMode system_mode = MPPT_CHARGER; // MPPT_CHARGER or NANOGRID 
+
+
+BatteryConfigUser battery_config_user;
+
+BatteryConfigUser::BatteryConfigUser()
 {
-    num_cells = 3;
+    type = BAT_TYPE_NMC; // mandatory
+    capacity = 12; // mandatory
+    num_cells = 3; // mandatory
 
-    // State: Standby
-    time_limit_recharge = 60; // sec
-    cell_voltage_recharge = 3.9; // V
-    cell_voltage_absolute_min = 2.7; // V   (under this voltage, battery is considered damaged)
-
+    // all batteries can optionally use these values, leave at 0 to set automatically
     // State: CC/bulk
-    charge_current_max = 8;  // A        PCB maximum: 20 A
+    charge_current_max = 0;        // A
+    current_cutoff_CV = 0;       // A
 
+    // Lithium batteries can optionally use these values, leave at 0 to set automatically
     // State: CV/absorption
-    cell_voltage_max = 4.1;        // max voltage per cell
-    time_limit_CV = 120*60; // sec
-    current_cutoff_CV = 1.0; // A
+    cell_voltage_max = 0;        // max charge voltage per cell
+    cell_voltage_recharge = 0;   // when voltage drops below start charging after battery full
 
-    // State: float/trickle
-    trickle_enabled = false;
-    cell_voltage_trickle = 2.3;    // target voltage for trickle charging of lead-acid batteries
-    time_trickle_recharge = 30*60;     // sec
-
-    // State: equalization
-    equalization_enabled = false;
-    cell_voltage_equalization = 2.5; // V
-    time_limit_equalization = 60*60; // sec
-    current_limit_equalization = 1.0; // A
-    equalization_trigger_time = 8; // weeks
-    equalization_trigger_deep_cycles = 10; // times
-
-    cell_voltage_load_disconnect = 3.3;
-    cell_voltage_load_reconnect = 3.6;
-
-    // TODO
-    temperature_compensation = 1.0;
+    cell_voltage_load_disconnect = 0; // when discharging, stop power to load measure battery voltage drops below this value
+    cell_voltage_load_reconnect = 0;  // when charging, only start power to load if reaching this battery voltage  
 }

--- a/src/data_objects.h
+++ b/src/data_objects.h
@@ -31,6 +31,8 @@ extern load_output_t load;
 extern dcdc_port_t hs_port;
 extern dcdc_port_t ls_port;
 
+extern BatteryConfigUser battery_config_user;
+extern const SystemMode system_mode; // we leave it fixed for the runtime for now
 
 extern const data_object_t dataObjects[]; // see output_can.cpp
 extern const size_t dataObjectsCount;

--- a/src/dcdc.cpp
+++ b/src/dcdc.cpp
@@ -41,18 +41,23 @@ void dcdc_port_init_bat(dcdc_port_t *port, battery_t *bat)
 {
     port->input_allowed = true;     // discharging allowed
     port->output_allowed = true;    // charging allowed
-    port->voltage_output_target = bat->cell_voltage_max * bat->num_cells;
-    port->current_output_max = bat->charge_current_max;
-    port->current_input_max = -bat->charge_current_max;          // TODO: discharge current
-    port->voltage_output_min = bat->cell_voltage_absolute_min * bat->num_cells;
-    port->voltage_input_stop = bat->cell_voltage_load_disconnect * bat->num_cells;
+
+
     port->voltage_input_target = bat->cell_voltage_load_reconnect * bat->num_cells;
+    port->voltage_input_stop = bat->cell_voltage_load_disconnect * bat->num_cells;
+    port->current_input_max = -bat->charge_current_max;          // TODO: discharge current
+
+    port->voltage_output_target = bat->cell_voltage_max * bat->num_cells;
+    port->voltage_output_min = bat->cell_voltage_absolute_min * bat->num_cells;
+    port->current_output_max = bat->charge_current_max;
+
 }
 
 void dcdc_port_init_solar(dcdc_port_t *port)
 {
     port->input_allowed = true;         // PV panel may provide power to solar input of DC/DC
     port->output_allowed = false;
+    
     port->voltage_input_target = 16.0;
     port->voltage_input_stop = 14.0;
     port->current_input_max = -18.0;
@@ -62,13 +67,15 @@ void dcdc_port_init_nanogrid(dcdc_port_t *port)
 {
     port->input_allowed = true;
     port->output_allowed = true;
-    port->voltage_output_target = 23.0;        // starting idle mode above this point
-    port->droop_resistance = 1.0;           // 1 Ohm means 1V change of target voltage per amp
-    port->current_output_max = 5.0;
-    port->current_input_max = -5.0;
-    port->voltage_output_min = 10.0;
+
     port->voltage_input_target = 25.0;      // starting buck mode above this point
     port->voltage_input_stop = 20.0;        // stopping buck mode below this point
+    port->current_input_max = -5.0;
+    
+    port->voltage_output_target = 23.0;        // starting idle mode above this point
+    port->current_output_max = 5.0;
+    port->voltage_output_min = 10.0;
+    port->droop_resistance = 1.0;           // 1 Ohm means 1V change of target voltage per amp
 }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -97,8 +97,15 @@ int main()
     time_t last_second = time(NULL);
 
     // high-side port of DC/DC (solar for typical MPPT)
-    //dcdc_port_init_solar(&hs_port);
-    dcdc_port_init_nanogrid(&hs_port);
+    switch(system_mode)
+    {
+        case NANOGRID:
+           dcdc_port_init_nanogrid(&hs_port);
+            break;
+        case MPPT_CHARGER:
+            dcdc_port_init_solar(&hs_port);
+            break;
+    }
     
     // low-side port (battery in most cases)
     dcdc_port_init_bat(&ls_port, &bat);
@@ -194,7 +201,7 @@ void setup()
     //printf("\nSerial interface started...\n");
     //freopen("/serial", "w", stdout);  // retarget stdout
 
-    battery_init(&bat, BAT_TYPE_FLOODED, 7, 6);
+    battery_init(&bat, battery_config_user);
     //battery_init(&bat, BAT_TYPE_LFP, 20, 4);
 
     dcdc_init(&dcdc);

--- a/src/structs.h
+++ b/src/structs.h
@@ -3,8 +3,8 @@
 #ifndef __STRUCTS_H_
 #define __STRUCTS_H_
 
-#include "data_objects.h"
 #include <stdbool.h>
+
 
 #ifdef __cplusplus
 extern "C" {
@@ -50,6 +50,7 @@ typedef struct
     float current_limit_equalization;     // A
     int equalization_trigger_time;        // weeks
     int equalization_trigger_deep_cycles; // times
+
 
     float cell_voltage_load_disconnect;
     float cell_voltage_load_reconnect;
@@ -191,5 +192,50 @@ typedef struct {
 #ifdef __cplusplus
 }
 #endif
+
+// we use this to define the devices basic operation mode
+enum SystemMode
+{
+    MPPT_CHARGER, 
+    // accept input power on the high side port and charge battery / supply load on the low side port
+    NANOGRID, 
+    // accept input power (if available and need for charging) or 
+    // provide output power (if no other power source on the grid and battery charged) on the high side port 
+    // and dis/charge battery on the low side port, battery voltage must be lower than nano grid voltage.
+};
+
+struct BatteryConfigUser
+{
+    BatteryConfigUser();
+
+    enum BatteryType type;  // mandatory, is used to determine charging strategy and cell voltage limits,
+                            // see structs.h BatteryType for complete list
+
+    float capacity;         // mandatory, what is the capacity of the battery (pack), unit: Ah
+                            // if you have cells in parallel, add the individual capacitie
+                            // value is not too critical, it is mainly used to determine charge currents.
+
+    uint8_t num_cells;      // mandatory, how many cells are connected in series
+
+
+    // all batteries will optionally use these values, leave at 0 to have these calculated automatically
+    // State: CC/bulk
+    float charge_current_max;           // never user more than this current for charging, unit: A
+    float current_cutoff_CV;            // stop the final constant voltage charging phase if the charge current falls below this
+                                        // value, unit: A
+
+    // Lithium batteries can optionally will optionally use these values, leave at 0 to have these calculated automatically
+    float cell_voltage_max;         // max charge voltage per cell, switch at this voltage from constant current (CC) to constant 
+                                    // voltage charging (CV) phase. 
+    float cell_voltage_recharge;    // when voltage drops below start charging after battery has been fully charged and charging 
+                                    // was stopped
+                                    // setting it too close to the max voltage will cause more charging stress on lithium based
+                                    // batteries 
+
+    float cell_voltage_load_disconnect; // when discharging, stop power to load measure battery voltage drops below this value
+    float cell_voltage_load_reconnect;  // when charging, only start power to load if reaching this battery voltage  
+
+};
+
 
 #endif // STRUCTS_H

--- a/src/structs.h
+++ b/src/structs.h
@@ -19,14 +19,16 @@ extern "C" {
 
 typedef struct
 {
-    // configuration data (r any time, write only at startup / init, change requires reinit of charger )
+    // configuration data (read any time, write only at startup / init, change requires reinit of charger )
     int num_cells;
-    int capacity;
+    float capacity;                   // Ah
 
     // State: Standby
     int time_limit_recharge;         // sec
     float cell_voltage_recharge;     // V
+
     float cell_voltage_absolute_min; // V   (below this voltage the battery is considered damaged)
+    float cell_voltage_absolute_max; // V   (above this voltage the battery can be damaged)
 
     // State: CC/bulk
     float charge_current_max;        // A
@@ -52,6 +54,7 @@ typedef struct
     float cell_voltage_load_disconnect;
     float cell_voltage_load_reconnect;
 
+    // used to calculate state of charge information 
     float cell_ocv_full;
     float cell_ocv_empty;
 
@@ -80,13 +83,14 @@ typedef struct
 } battery_t;
 
 // battery types 
-enum {
-    BAT_TYPE_NONE,        // stafe standard settings
-    BAT_TYPE_FLOODED,        // old flooded (wet) lead-acid batteries
-    BAT_TYPE_GEL,            // VRLA gel batteries (maintainance-free)
-    BAT_TYPE_AGM,            // AGM batteries (maintainance-free)
-    BAT_TYPE_LFP,            // LiFePO4 Li-ion batteries (3.3V nominal)
-    BAT_TYPE_NMC             // NMC/Graphite Li-ion batteries (3.7V nominal)
+enum BatteryType {
+    BAT_TYPE_NONE = 0,        // stafe standard settings
+    BAT_TYPE_FLOODED,         // old flooded (wet) lead-acid batteries
+    BAT_TYPE_GEL,             // VRLA gel batteries (maintainance-free)
+    BAT_TYPE_AGM,             // AGM batteries (maintainance-free)
+    BAT_TYPE_LFP,             // LiFePO4 Li-ion batteries (3.3V nominal)
+    BAT_TYPE_NMC,             // NMC/Graphite Li-ion batteries (3.7V nominal)
+    BAT_TYPE_NMC_HV,          // NMC/Graphite High Voltage Li-ion batteries (3.7V nominal, 4.35 max)
 };
 
 // possible charger states


### PR DESCRIPTION
How to do the user configuration:
Copy the most relevant template to config.cpp, edit if necessary and then compile.
config.cpp is intentionally not part of the git managed source code
since it represents the user specific configuration part
which varies across different firmware builds.


In addition to the mandatory arguments cell type, number in series and capacity,
the code now accepts a partially configure battery_t structure (you provide
various voltage levels and charge currents via BatteryConfigUser) for Lithium based cells, checks the configuration values for sanity and tries to adjust if outside valid operational limits. The defaults try
to balance between charging stress and capacity loss.
Charge is by default to about 90% maximum full charge, and discharge stops around
20%-30%.

For lead acid cells all voltage levels and currents are set / calculated based
on the mandatory parameters, no configuration of voltage levels possible.

We may change that, but I don't have enough no knowledge about valid ranges
etc.

I added a high voltage lithium chemistry for cells which have typically
4.35 voltage limit (vs. 4.2 normally).
